### PR TITLE
JUnit assertThrows

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,6 +55,11 @@
       <version>4.13</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/test/java/org/apache/commons/digester3/DTDValidationTestCase.java
+++ b/core/src/test/java/org/apache/commons/digester3/DTDValidationTestCase.java
@@ -17,11 +17,13 @@
 package org.apache.commons.digester3;
 
 import static org.apache.commons.digester3.binder.DigesterLoader.newLoader;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 
 import org.apache.commons.digester3.binder.AbstractRulesModule;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -29,50 +31,50 @@ import org.xml.sax.SAXParseException;
 /**
  * Tests for entity resolution and dtd validation
  */
-public class DTDValidationTestCase
-{
+public class DTDValidationTestCase {
 
-    @Test( expected = SAXParseException.class )
-    public void testDigesterDTDError()
-        throws Exception
-    {
-        newLoader( new AbstractRulesModule() {
+    @Test
+    public void testDigesterDTDError() {
 
+        // FIXME Simplification once upgraded to Java 1.8 and use lambda
+        final Executable testMethod = new Executable() {
             @Override
-            protected void configure()
-            {
-                // do nothing
+            public void execute() throws Throwable {
+                newLoader(new AbstractRulesModule() {
+
+                    @Override
+                    protected void configure() {
+                        // do nothing
+                    }
+
+                })
+                        .setValidating(true)
+                        .setErrorHandler(new ErrorHandler() {
+
+                            @Override
+                            public void warning(final SAXParseException e)
+                                    throws SAXException {
+                                throw e;
+                            }
+
+                            @Override
+                            public void fatalError(final SAXParseException e)
+                                    throws SAXException {
+                                throw e;
+                            }
+
+                            @Override
+                            public void error(final SAXParseException e)
+                                    throws SAXException {
+                                throw e;
+                            }
+
+                        })
+                        .newDigester()
+                        .parse(new File("src/test/resources/org/apache/commons/digester3/document-with-relative-dtd-error.xml"));
             }
-
-        } )
-        .setValidating( true )
-        .setErrorHandler( new ErrorHandler()
-        {
-
-            @Override
-            public void warning( final SAXParseException e )
-                throws SAXException
-            {
-                throw e;
-            }
-
-            @Override
-            public void fatalError( final SAXParseException e )
-                throws SAXException
-            {
-                throw e;
-            }
-
-            @Override
-            public void error( final SAXParseException e )
-                throws SAXException
-            {
-                throw e;
-            }
-
-        } )
-        .newDigester()
-        .parse( new File( "src/test/resources/org/apache/commons/digester3/document-with-relative-dtd-error.xml" ) );
+        };
+        assertThrows(SAXParseException.class, testMethod);
     }
 
     @Test

--- a/core/src/test/java/org/apache/commons/digester3/Digester153TestCase.java
+++ b/core/src/test/java/org/apache/commons/digester3/Digester153TestCase.java
@@ -23,12 +23,14 @@ import static org.apache.commons.digester3.binder.DigesterLoader.newLoader;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.digester3.annotations.FromAnnotationsRuleModule;
 import org.apache.commons.digester3.binder.AbstractRulesModule;
 import org.apache.commons.digester3.binder.RulesModule;
 import org.apache.commons.digester3.xmlrules.FromXmlRulesModule;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.xml.sax.SAXParseException;
 
 /**
@@ -170,17 +172,22 @@ public final class Digester153TestCase
         assertEquals( 0D, bean.getDoubleProperty(), 0 );
     }
 
-    @Test( expected = SAXParseException.class )
-    public void basicConstructorWithWrongParameters()
-        throws Exception
-    {
+    @Test
+    public void basicConstructorWithWrongParameters() {
         final ObjectCreateRule createRule = new ObjectCreateRule( TestBean.class );
         createRule.setConstructorArgumentTypes( boolean.class );
 
         final Digester digester = new Digester();
         digester.addRule( "toplevel/bean", createRule );
 
-        digester.parse( getClass().getResourceAsStream( "BasicConstructor.xml" ) );
+        // FIXME Simplification once upgraded to Java 1.8 and use lambda
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                digester.parse(getClass().getResourceAsStream("BasicConstructor.xml"));
+            }
+        };
+        assertThrows(SAXParseException.class, testMethod);
     }
 
     @Test

--- a/core/src/test/java/org/apache/commons/digester3/Digester171TestCase.java
+++ b/core/src/test/java/org/apache/commons/digester3/Digester171TestCase.java
@@ -20,11 +20,13 @@ package org.apache.commons.digester3;
  */
 
 import static org.apache.commons.digester3.binder.DigesterLoader.newLoader;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 
 import org.apache.commons.digester3.binder.AbstractRulesModule;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXParseException;
 
@@ -50,26 +52,29 @@ public class Digester171TestCase
         .parse( new File( "src/test/resources/org/apache/commons/digester3/document-with-relative-dtd-error.xml" ) );
     }
 
-    @Test( expected = SAXParseException.class )
-    public void testDefaultThrowingErrorHandler()
-        throws Exception
-    {
+    @Test
+    public void testDefaultThrowingErrorHandler() {
         final ErrorHandler customErrorHandler = new DefaultThrowingErrorHandler();
 
-        newLoader( new AbstractRulesModule()
-        {
-
+        // FIXME Simplification once upgraded to Java 1.8 and use lambda
+        final Executable testMethod = new Executable() {
             @Override
-            protected void configure()
-            {
-                // do nothing
-            }
+            public void execute() throws Throwable {
+                newLoader(new AbstractRulesModule() {
 
-        } )
-        .setFeature( "http://xml.org/sax/features/validation", true )
-        .setErrorHandler( customErrorHandler )
-        .newDigester()
-        .parse( new File( "src/test/resources/org/apache/commons/digester3/document-with-relative-dtd-error.xml" ) );
+                    @Override
+                    protected void configure() {
+                        // do nothing
+                    }
+
+                })
+                        .setFeature("http://xml.org/sax/features/validation", true)
+                        .setErrorHandler(customErrorHandler)
+                        .newDigester()
+                        .parse(new File("src/test/resources/org/apache/commons/digester3/document-with-relative-dtd-error.xml"));
+            }
+        };
+        assertThrows(SAXParseException.class, testMethod);
     }
 
 }

--- a/core/src/test/java/org/apache/commons/digester3/annotations/failingtests/FailingTestCase.java
+++ b/core/src/test/java/org/apache/commons/digester3/annotations/failingtests/FailingTestCase.java
@@ -18,10 +18,15 @@
 package org.apache.commons.digester3.annotations.failingtests;
 
 import static org.apache.commons.digester3.binder.DigesterLoader.newLoader;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.digester3.annotations.FromAnnotationsRuleModule;
 import org.apache.commons.digester3.binder.DigesterLoadingException;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public final class FailingTestCase
 {
@@ -29,20 +34,25 @@ public final class FailingTestCase
     /**
      * Tests to make sure loader fails
      */
-    @Test(expected = DigesterLoadingException.class)
+    @Test
     public void failsBecauseFailingDigesterLoaderHandlerFactory() {
 
-        newLoader(new FromAnnotationsRuleModule()
-        {
+        // FIXME Simplification once upgraded to Java 1.8 and use lambda
+        final Executable testMethod = new Executable() {
+            public void execute() throws Throwable {
+                newLoader(new FromAnnotationsRuleModule() {
 
-            @Override
-            protected void configureRules()
-            {
-                useAnnotationHandlerFactory( new FailingDigesterLoaderHandlerFactory() );
-                bindRulesFrom( BeanWithFakeHandler.class );
+                    @Override
+                    protected void configureRules() {
+                        useAnnotationHandlerFactory(new FailingDigesterLoaderHandlerFactory());
+                        bindRulesFrom(BeanWithFakeHandler.class);
+                    }
+
+                }).newDigester();
             }
-
-        }).newDigester();
+        };
+        final DigesterLoadingException thrown = assertThrows(DigesterLoadingException.class, testMethod);
+        assertThat(thrown.getMessage(), is(startsWith("Digester creation errors:")));
     }
 
 }

--- a/core/src/test/java/org/apache/commons/digester3/xmlrules/IncludeTest.java
+++ b/core/src/test/java/org/apache/commons/digester3/xmlrules/IncludeTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.digester3.xmlrules;
 
 import static org.apache.commons.digester3.binder.DigesterLoader.newLoader;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.StringReader;
 import java.net.URL;
@@ -30,6 +31,7 @@ import org.apache.commons.digester3.Digester;
 import org.apache.commons.digester3.Rule;
 import org.apache.commons.digester3.binder.AbstractRulesModule;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 /**
  * Test for the include class functionality
@@ -130,21 +132,25 @@ public class IncludeTest
     /**
      * Validates that circular includes are detected and result in an exception
      */
-    @Test( expected = org.apache.commons.digester3.binder.DigesterLoadingException.class )
-    public void testCircularInclude()
-        throws Exception
-    {
+    @Test
+    public void testCircularInclude() {
         final URL url = ClassLoader.getSystemResource( "org/apache/commons/digester3/xmlrules/testCircularRules.xml" );
-        newLoader( new FromXmlRulesModule()
-        {
 
+        // FIXME Simplification once upgraded to Java 1.8 and use lambda
+        final Executable testMethod = new Executable() {
             @Override
-            protected void loadRules()
-            {
-                loadXMLRules( url );
-            }
+            public void execute() throws Throwable {
+                newLoader(new FromXmlRulesModule() {
 
-        }).newDigester();
+                    @Override
+                    protected void loadRules() {
+                        loadXMLRules(url);
+                    }
+
+                }).newDigester();
+            }
+        };
+        assertThrows(org.apache.commons.digester3.binder.DigesterLoadingException.class, testMethod);
     }
 
 }


### PR DESCRIPTION
Code could be cleaner if it could be Java 1.8.

I could set `<maven.compiler.testSource>1.8</maven.compiler.testSource>`... thoughts???